### PR TITLE
Add handling of external joysticks 3..6

### DIFF
--- a/src/dave.cpp
+++ b/src/dave.cpp
@@ -626,20 +626,32 @@ namespace Ep128 {
             n &= uint8_t(0xF9 | (mouseInput >> 3));
             // EXT1 joystick fire buttons
             n &= uint8_t(0xF8 | (keyboardState[14] >> 4));
+            // EXT3/5 fire buttons actually overlap with EXT1 fire2 and 3
+            n &= uint8_t(0xFD | (keyboardState[12] >> 3));
+            n &= uint8_t(0xFB | (keyboardState[10] >> 2));
           }
           else {
             if (!(mouseInput & 0x80))   // EnterMice data input on column K
               n &= uint8_t(0xFD | ((mouseInput << 1) >> (keyboardRow - 1)));
             // EXT1 joystick (mapped to row 14)
             n &= uint8_t(0xFE | (keyboardState[14] >> (4 - keyboardRow)));
+            n &= uint8_t(0xFD | ((keyboardState[12] << 1) >> (4 - keyboardRow)));
+            n &= uint8_t(0xFB | ((keyboardState[10] << 2) >> (4 - keyboardRow)));
           }
         }
         else if (keyboardRow < 10) {
           // external joystick 2 (mapped to keyboard row 15)
-          if (keyboardRow == 5)         // fire buttons
+          if (keyboardRow == 5) {         // fire buttons
             n &= uint8_t(0xF8 | (keyboardState[15] >> 4));
-          else
+            // EXT4/6 fire buttons actually overlap with EXT2 fire2 and 3
+            n &= uint8_t(0xFD | (keyboardState[13] >> 3));
+            n &= uint8_t(0xFB | (keyboardState[11] >> 2));
+          }
+          else {
             n &= uint8_t(0xFE | (keyboardState[15] >> (9 - keyboardRow)));
+            n &= uint8_t(0xFD | ((keyboardState[13] << 1 ) >> (9 - keyboardRow)));
+            n &= uint8_t(0xFB | ((keyboardState[11] << 2 ) >> (9 - keyboardRow)));
+            }
         }
         return n;
       }

--- a/src/dave.hpp
+++ b/src/dave.hpp
@@ -224,9 +224,17 @@ namespace Ep128 {
      * +------+-------+-------+-------+-------+-------+-------+-------+-------+
      * | 0x48 |     I |       |     O |     @ |     P |     [ |       |       |
      * +------+-------+-------+-------+-------+-------+-------+-------+-------+
-     * | 0x70 | JOY1R | JOY1L | JOY1D | JOY1U | JOY1F | JOY1F2| JOY1F3|       |
+     * | 0x50 | JOY5R | JOY5L | JOY5D | JOY5U | JOY5F |       |       |       | Joysticks 5..6 are decoded from column L
      * +------+-------+-------+-------+-------+-------+-------+-------+-------+
-     * | 0x78 | JOY2R | JOY2L | JOY2D | JOY2U | JOY2F | JOY2F2| JOY2F3|       |
+     * | 0x58 | JOY6R | JOY6L | JOY6D | JOY6U | JOY6F |       |       |       |
+     * +------+-------+-------+-------+-------+-------+-------+-------+-------+
+     * | 0x60 | JOY3R | JOY3L | JOY3D | JOY3U | JOY3F |       |       |       | Joysticks 3..4 are decoded from column K
+     * +------+-------+-------+-------+-------+-------+-------+-------+-------+
+     * | 0x68 | JOY4R | JOY4L | JOY4D | JOY4U | JOY4F |       |       |       |
+     * +------+-------+-------+-------+-------+-------+-------+-------+-------+
+     * | 0x70 | JOY1R | JOY1L | JOY1D | JOY1U | JOY1F | JOY1F2| JOY1F3|       | Fire 2 and 3 are overlapping with Joy3F and Joy5F
+     * +------+-------+-------+-------+-------+-------+-------+-------+-------+
+     * | 0x78 | JOY2R | JOY2L | JOY2D | JOY2U | JOY2F | JOY2F2| JOY2F3|       | Fire 2 and 3 are overlapping with Joy4F and Joy6F
      * +------+-------+-------+-------+-------+-------+-------+-------+-------+
      */
     void setKeyboardState(int keyCode, int state);


### PR DESCRIPTION
These joysticks are using column K and L for status reading, on the
same physical ports as external 1 and 2 with column J.
Mapped to previously unused keyboard matrix entries 0x50..0x6F.
2nd and 3rd fire button of Ext1/2 is the same as fire button of
Ext3/4 and Ext5/6, though keyboard matrix position is different.
Tested with Raster Runner and Team Hat Trick.

Keyboard map can only be set from config file, no GUI support added.